### PR TITLE
Add support for comments starting with '#'

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -78,6 +78,10 @@ pub fn tokenize(path: Option<String>, source: Option<&mut Vec<u8>>) -> (Vec<Toke
                     state = State::MaybeComment;
                     word_start += 1;
                 }
+                else if c == '#' {
+                    state = State::Comment;
+                    word_start += 1;
+                }
                 else {
                     // The current word won't start here yet
                     word_start += 1;
@@ -121,7 +125,7 @@ pub fn tokenize(path: Option<String>, source: Option<&mut Vec<u8>>) -> (Vec<Toke
                     word_start += 1;
                 }
             }
-            // This certainly is a comment. ("//")
+            // This certainly is a comment. ("//" or "#")
             State::Comment => {
                 if c == '\n' || c == '\r' {
                     state = State::Separator;


### PR DESCRIPTION
This enables the use of shebangs, as described in issue #2.

If that is not desired functionality, feel free to close the issue and reject the PR.